### PR TITLE
chore: Fix deploy production workflow

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       pr_no:
-        description: "PR-numbered container set to deploy"
+        description: "PR or tag to deploy (default = 'test')"
         type: number
         required: false
+        default: "test"
 
 concurrency:
   # Do not interrupt previous workflows
@@ -14,25 +15,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  vars:
-    name: Set Variables
-    outputs:
-      pr: ${{ steps.pr.outputs.pr }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 1
-    steps:
-      # Get PR number for squash merges to main
-      - name: PR Number
-        id: pr
-        uses: bcgov-nr/action-get-pr@v0.0.1
-  
   deploy-prod:
     name: Deploy (prod)
-    needs: [vars]
     uses: ./.github/workflows/.deployer.yml
     secrets: inherit
     with:
       environment: prod
+      tag: ${{ inputs.pr_no}}
       params:
         --set cms.deploymentStrategy=RollingUpdate
         --set frontend.deploymentStrategy=RollingUpdate
@@ -43,7 +32,7 @@ jobs:
         --set frontend.replicaCount=2
   promote:
     name: Promote Images
-    needs: [deploy-prod, vars]
+    needs: [deploy-prod]
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -56,5 +45,5 @@ jobs:
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}/${{ matrix.package }}
-          target: ${{ needs.vars.outputs.pr }}
+          target: ${{ inputs.pr_no }}
           tags: prod


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

In previous PR the production deployment process was separated out into it's own manual workflow. However this workflow crashed due to one of the imported actions being unable to find a pr number. 

Instead of using a PR number I have updated the workflow to look for packages tagged with 'test' instead.

This is a bit of trial and error and may still not run correctly

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-bcmi-20-frontend.apps.silver.devops.gov.bc.ca)
- [CMS](https://nr-bcmi-20-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/merge.yml)