### PR TITLE
[MDS-6462] Add bcgovpubcode.yml

### DIFF
--- a/bcgovpubcode.yml
+++ b/bcgovpubcode.yml
@@ -1,0 +1,35 @@
+version: 1
+data_management_roles:
+  data_custodian: Colin Squirrell
+  product_owner: Rebecca Stevenson
+product_external_dependencies:
+  notification_standard: []
+product_information:
+  api_specifications: []
+  ministry:
+    - Energy, Mines and Low Carbon Innovation
+  product_acronym: BCMI
+  product_description: Public facing interface for information on major mines in British Columbia
+  product_name: British Columbia Mine Information
+  product_status: maturing
+  product_urls:
+    - https://mines.nrs.gov.bc.ca
+  program_area: Mines Digital Services
+product_technology_information:
+  backend_frameworks: []
+  backend_languages_version: []
+  ci_cd_tools:
+    - GitHub-Actions
+    - Helm
+  data_storage_platforms:
+    - Postgresql
+  frontend_frameworks:
+    - name: Angular
+      version: 18.2.3
+  frontend_languages:
+    - name: TypeScript
+      version: 5.5.4
+  hosting_platforms:
+    - Private-Cloud-Openshift
+  spatial_mapping_technologies:
+    - Leaflet


### PR DESCRIPTION
## Objective 

[MDS-6462](https://bcmines.atlassian.net/browse/MDS-6462)

bcgovpubcode.yml is a metadata standard for repositories containing software developed or acquired by the Public Administration, aimed at making them easily discoverable and thus reusable by other entities.

https://pubcode.apps.silver.devops.gov.bc.ca/

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-bcmi-48-frontend.apps.silver.devops.gov.bc.ca)
- [CMS](https://nr-bcmi-48-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/merge.yml)