### PR TITLE
[MDS-6282] Fix loading of strapi dashboard when deployed in Openshfit

### DIFF
--- a/cms/config/middlewares.ts
+++ b/cms/config/middlewares.ts
@@ -8,6 +8,6 @@ export default [
   'strapi::body',
   'strapi::session',
   'strapi::favicon',
-  'strapi::public',
   {resolve: './src/middlewares/admin-redirect'},
+  'strapi::public',
 ];

--- a/cms/config/server.ts
+++ b/cms/config/server.ts
@@ -1,6 +1,7 @@
 export default ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
+  proxy: env.bool('TRUST_PROXY', false),
   app: {
     keys: env.array('APP_KEYS'),
   },

--- a/frontend/src/app/services/project.service.ts
+++ b/frontend/src/app/services/project.service.ts
@@ -1,4 +1,4 @@
-import { throwError as observableThrowError, Observable, forkJoin } from 'rxjs';
+import { throwError as observableThrowError, Observable, forkJoin, of } from 'rxjs';
 import { switchMap, catchError, map } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
@@ -55,6 +55,10 @@ export class ProjectService {
     return this.api.getProjectCollections(this.project._id).pipe(
       map((res: any) => this.processCollections(res && res[0] && res[0].searchResults ? res[0].searchResults : null)),
       switchMap((collections: any[]) => {
+        if (!collections.length) {
+          return of(collections);
+        }
+
         // Send all getCollectionDocuments API requests concurrently and combine the results as a single array
         return forkJoin(
           collections.map(collection => {


### PR DESCRIPTION
# Description

Attempts to fix the following error when logging into strapi in the test env. I tracked (hope so) it down to missing proxy config (breaking change is v5). https://docs.strapi.io/cms/migration/v4-to-v5/breaking-changes/server-proxy

<img width="777" height="203" alt="image" src="https://github.com/user-attachments/assets/7715d94c-d664-4a7e-8590-d611aa78b1a6" />

Also fixes these two bugs:
- Mine detail view doesn't load when no documents have been published (which apply to most mines in test)
- Strapi doesn't redirect to SSO login page when not logged in

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested locally


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code


## Further comments


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-bcmi-176-frontend.apps.silver.devops.gov.bc.ca)
- [CMS](https://nr-bcmi-176-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/merge.yml)