### PR TITLE
MDS-6282 Fixed error when editing content in Strapi

### DIFF
--- a/cms/config/admin.ts
+++ b/cms/config/admin.ts
@@ -10,6 +10,9 @@ export default ({ env }) => ({
       salt: env('TRANSFER_TOKEN_SALT'),
     },
   },
+  preview: {
+    enabled: false
+  },
   flags: {
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),

--- a/cms/config/plugins.ts
+++ b/cms/config/plugins.ts
@@ -6,6 +6,9 @@ export default ({ env }) => ({
             maxLimit: 100
         }
     },
+    ckeditor5: {
+        enabled: true,
+    },
     'strapi-plugin-sso': {
         enabled: true,
         config: {

--- a/cms/src/admin/app.tsx
+++ b/cms/src/admin/app.tsx
@@ -1,6 +1,20 @@
 import MenuLogo from "../extensions/BC_Logo.png";
+import { setPluginConfig, getPluginPresets } from '@_sh/strapi-plugin-ckeditor';
 
 export default {
+  register() {
+    const defaultPresets = getPluginPresets();
+    setPluginConfig({
+      presets: [
+        ...Object.values(defaultPresets),
+        {
+          ...defaultPresets.defaultHtml,
+          name: 'toolbar',
+          description: 'Toolbar HTML editor',
+        },
+      ],
+    });
+  },
   config: {
     locales: [
       'en'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fixes an issue where the content editor for pages in Strapi would never load.

Cause: Some boilerplate config that is required in the latest version of ckeditor

Before:

<img width="1725" height="734" alt="image" src="https://github.com/user-attachments/assets/59f2526c-9b50-4a03-a75b-69a5eb036507" />

After:

<img width="1724" height="788" alt="image" src="https://github.com/user-attachments/assets/491c9388-dfa3-4d69-bbab-ee7998fbf5a4" />




---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-bcmi-178-frontend.apps.silver.devops.gov.bc.ca)
- [CMS](https://nr-bcmi-178-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/merge.yml)