### PR TITLE
[MDS-6282] Removed strapi resource limits to fix restarts

### DIFF
--- a/charts/app/templates/cms/templates/deployment.yaml
+++ b/charts/app/templates/cms/templates/deployment.yaml
@@ -69,9 +69,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: # this is optional
-            limits:
-              cpu: 300m
-              memory: 300Mi
             requests:
               cpu: 100m
               memory: 150Mi

--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -68,9 +68,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources:
-            limits:
-              cpu: 150m
-              memory: 300Mi
             requests:
               cpu: 100m
               memory: 100Mi

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -70,9 +70,6 @@ cms:
       - prod/api-2
     #-- resources specific to vault initContainer. it is optional and is an object.
     resources:
-      limits:
-        cpu: 50m
-        memory: 50Mi
       requests:
         cpu: 50m
         memory: 25Mi
@@ -169,7 +166,3 @@ bitnamipg:
       requests:
         cpu: 50m
         memory: 150Mi
-      limits:
-        cpu: 200m
-        memory: 300Mi
-


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Strapi crashes in test from time to time due to an out of memory issue. This PR removes the limits (default to the platform defined defaults instead)

<img width="1889" height="151" alt="image" src="https://github.com/user-attachments/assets/3b5c7df5-a495-4097-99e6-2914a2ed1b94" />


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-bcmi-182-frontend.apps.silver.devops.gov.bc.ca)
- [CMS](https://nr-bcmi-182-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/merge.yml)