### PR TITLE
MDS-6282 Fixed resolving of content loaded by graphql

### DIFF
--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -10,12 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@_sh/strapi-plugin-ckeditor": "7.1.1",
-        "@strapi/plugin-graphql": "5.40.0",
-        "@strapi/plugin-users-permissions": "5.40.0",
-        "@strapi/strapi": "5.41.1",
+        "@strapi/plugin-graphql": "5.43.0",
+        "@strapi/plugin-users-permissions": "5.43.0",
+        "@strapi/strapi": "5.43.0",
         "pg": "8.8.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
+        "react": "18.3.0",
+        "react-dom": "18.3.0",
         "react-router-dom": "6.30.3",
         "strapi-plugin-sso": "1.0.8",
         "styled-components": "6.3.12"
@@ -2087,9 +2087,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
-      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -2119,9 +2119,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.40.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
-      "integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.6.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3561,9 +3561,9 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
-      "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
       "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
@@ -3587,9 +3587,9 @@
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
-      "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -4958,39 +4958,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-effect-event/node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
@@ -5134,30 +5101,6 @@
       "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
       "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
       "license": "MIT"
-    },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
-      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
-      "license": "MIT",
-      "dependencies": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.0.2"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -5743,9 +5686,9 @@
       "license": "MIT"
     },
     "node_modules/@strapi/admin": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-5.41.1.tgz",
-      "integrity": "sha512-IhdIDeX/o/5rVS7BGjzuHtknf7mLHrLUppgwyMKsTTGeo38L/x01OrW4DifYTdpJjfuxPt4bwpxJeARHJheBog==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-5.43.0.tgz",
+      "integrity": "sha512-zN2m1l1OALBkfdho+bECuEGREhTVQ+GT08wxQ8Sy6Vrxvp9DbHTtd6oL9dih4GZzbCWYbbPhrXW6HyJfFIADXg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@casl/ability": "6.7.5",
@@ -5755,14 +5698,14 @@
         "@reduxjs/toolkit": "1.9.7",
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/permissions": "5.41.1",
-        "@strapi/types": "5.41.1",
-        "@strapi/typescript-utils": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/permissions": "5.43.0",
+        "@strapi/types": "5.43.0",
+        "@strapi/typescript-utils": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "@testing-library/dom": "10.4.1",
         "@testing-library/react": "16.3.0",
         "@testing-library/user-event": "14.6.1",
-        "axios": "1.13.5",
+        "axios": "1.15.1",
         "bcryptjs": "2.4.3",
         "boxen": "5.1.2",
         "chalk": "^4.1.2",
@@ -5786,7 +5729,7 @@
         "koa-passport": "6.0.0",
         "koa-static": "5.0.0",
         "koa2-ratelimit": "^1.1.3",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "motion": "12.23.24",
         "ora": "5.4.1",
         "p-map": "4.0.0",
@@ -5825,33 +5768,74 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/admin/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@strapi/admin/node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/admin/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/@strapi/admin/node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@strapi/admin/node_modules/use-context-selector": {
       "version": "1.4.1",
@@ -5883,13 +5867,13 @@
       }
     },
     "node_modules/@strapi/cloud-cli": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/cloud-cli/-/cloud-cli-5.41.1.tgz",
-      "integrity": "sha512-J3ESa/YU8vi7zwB031FqroA+KwvRW2CKkWpc7A+ORWjIPFEx3XOM/q8c5nkBXzwGvEIdoyzJkii/ezcs8pljyw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/cloud-cli/-/cloud-cli-5.43.0.tgz",
+      "integrity": "sha512-FW8HwN6BwiKN/Q2KVjdTTNtsdF/goDYp7tHWzOTbXfANBY4htViUYB5JMwKW8GlNcTb9NKlgSVE+XQCPXQOfng==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@strapi/utils": "5.41.1",
-        "axios": "1.13.5",
+        "@strapi/utils": "5.43.0",
+        "axios": "1.15.1",
         "boxen": "5.1.2",
         "chalk": "4.1.2",
         "cli-progress": "3.12.0",
@@ -5900,8 +5884,8 @@
         "inquirer": "9.3.8",
         "jsonwebtoken": "9.0.0",
         "jwks-rsa": "3.1.0",
-        "lodash": "4.17.23",
-        "minimatch": "10.2.4",
+        "lodash": "4.18.1",
+        "minimatch": "10.2.5",
         "open": "8.4.0",
         "ora": "5.4.1",
         "pkg-up": "3.1.0",
@@ -5917,47 +5901,16 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/cloud-cli/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@strapi/cloud-cli/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/@strapi/cloud-cli/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@strapi/content-manager": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/content-manager/-/content-manager-5.41.1.tgz",
-      "integrity": "sha512-GWOsZGDJRLIyw6De820ilTCK3tSAxhmgNZ5CCjah0gOuxEVO9gXDHdWV1KwiO43Bca/5XDDuHorhtDVk01blbw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/content-manager/-/content-manager-5.43.0.tgz",
+      "integrity": "sha512-tnHe8m4VKyDiPhoWnocCHWRZ3Z0sI/PIUMR1peP1ehuOZrMWGbS6o0ELpEHz9vS7/90rLPtzC6Gqphux1ytTlg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
@@ -5968,15 +5921,15 @@
         "@sindresorhus/slugify": "1.1.0",
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/types": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/types": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "codemirror5": "npm:codemirror@^5.65.11",
         "date-fns": "2.30.0",
         "fractional-indexing": "3.2.0",
         "highlight.js": "^10.4.1",
         "immer": "9.0.21",
         "koa": "2.16.4",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "markdown-it": "^13.0.2",
         "markdown-it-abbr": "^1.0.4",
         "markdown-it-container": "^3.0.0",
@@ -6014,59 +5967,91 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/content-manager/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@strapi/content-manager/node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/content-manager/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/@strapi/content-manager/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+    "node_modules/@strapi/content-manager/node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/content-releases": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/content-releases/-/content-releases-5.41.1.tgz",
-      "integrity": "sha512-F+LrkedFRvH8QRNrz3A3zRGH7S60SmFDz5phE22xd9oBL+hSMFP07kwafEzJV4YSfkdtMMibCejG+BsKQ4lY/Q==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/content-releases/-/content-releases-5.43.0.tgz",
+      "integrity": "sha512-q947Bxsbh7zja4gzDIXGlWZ3utfh3AbFa05NsVPi7meQlusF15Jg0hDMUgmJcOBIAiLkpS5/rs2J3kc3XFlLhA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@reduxjs/toolkit": "1.9.7",
-        "@strapi/database": "5.41.1",
+        "@strapi/database": "5.43.0",
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/types": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/types": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "date-fns": "2.30.0",
         "date-fns-tz": "2.0.1",
         "formik": "2.4.5",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "qs": "6.15.0",
         "react-intl": "6.6.2",
         "react-redux": "8.1.3",
@@ -6085,47 +6070,79 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/content-releases/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@strapi/content-releases/node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/content-releases/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/@strapi/content-releases/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+    "node_modules/@strapi/content-releases/node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/content-type-builder": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/content-type-builder/-/content-type-builder-5.41.1.tgz",
-      "integrity": "sha512-zqTRDFp9o542zgk2cqATjtbgBtvENPXD0YIipwi0k/xPSOsUzzQVwI+09sGWGg3f1zbVgiDuuEPEHnmVM0GxoA==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/content-type-builder/-/content-type-builder-5.43.0.tgz",
+      "integrity": "sha512-xJWP+ez3d6SJ02pssz6Jux8yKZ4n4+0u1YA1JqLoJagN/26UOsclOSQjDjJp6dLdU1yf0FP7WlyvqPRd/Qzm5g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@ai-sdk/react": "2.0.120",
@@ -6136,15 +6153,15 @@
         "@reduxjs/toolkit": "1.9.7",
         "@sindresorhus/slugify": "1.1.0",
         "@strapi/design-system": "2.2.0",
-        "@strapi/generators": "5.41.1",
+        "@strapi/generators": "5.43.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/utils": "5.41.1",
+        "@strapi/utils": "5.43.0",
         "ai": "5.0.52",
         "date-fns": "2.30.0",
         "fs-extra": "11.2.0",
         "immer": "9.0.21",
         "jszip": "^3.10.1",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.8",
         "pluralize": "8.0.0",
         "qs": "6.15.0",
@@ -6167,33 +6184,74 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/content-type-builder/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@strapi/content-type-builder/node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/content-type-builder/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@strapi/content-type-builder/node_modules/zod": {
       "version": "3.25.67",
@@ -6205,22 +6263,22 @@
       }
     },
     "node_modules/@strapi/core": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/core/-/core-5.41.1.tgz",
-      "integrity": "sha512-1LmuXqnd+81EKacO8Y9+YZ2GTUAFpffsVZapRqRaLttuB8J/DiS14uMzUTk71zFOZ7c+32iQBESJQqYqWNU6ow==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/core/-/core-5.43.0.tgz",
+      "integrity": "sha512-b0DfzMVpa4Q8neY1p1n80c9PB9pHvd6mI/FdoWZEnA41yDfrASokqpIHbsKr0Qbg+k0wM11BUtpWuKtMRR4fhw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@koa/cors": "5.0.0",
         "@koa/router": "12.0.2",
         "@paralleldrive/cuid2": "2.2.2",
-        "@strapi/admin": "5.41.1",
-        "@strapi/database": "5.41.1",
-        "@strapi/generators": "5.41.1",
-        "@strapi/logger": "5.41.1",
-        "@strapi/permissions": "5.41.1",
-        "@strapi/types": "5.41.1",
-        "@strapi/typescript-utils": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/admin": "5.43.0",
+        "@strapi/database": "5.43.0",
+        "@strapi/generators": "5.43.0",
+        "@strapi/logger": "5.43.0",
+        "@strapi/permissions": "5.43.0",
+        "@strapi/types": "5.43.0",
+        "@strapi/typescript-utils": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "@vercel/stega": "0.1.2",
         "bcryptjs": "2.4.3",
         "boxen": "5.1.2",
@@ -6250,7 +6308,7 @@
         "koa-ip": "^2.1.3",
         "koa-session": "6.4.0",
         "koa-static": "5.0.0",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "mime-types": "2.1.35",
         "node-schedule": "2.1.1",
         "open": "8.4.0",
@@ -6262,29 +6320,7 @@
         "semver": "7.5.4",
         "statuses": "2.0.1",
         "typescript": "5.4.4",
-        "undici": "6.24.0",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/@strapi/core/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
+        "undici": "6.25.0",
         "yup": "0.32.9",
         "zod": "3.25.67"
       },
@@ -6294,9 +6330,9 @@
       }
     },
     "node_modules/@strapi/core/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/@strapi/core/node_modules/zod": {
@@ -6309,20 +6345,20 @@
       }
     },
     "node_modules/@strapi/data-transfer": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-5.41.1.tgz",
-      "integrity": "sha512-6MMw18dAikbeI8wZwqVMoo37ODbHBEgLl8jMIxrih5jjdDJ5AxmMx6TmQdU7N/DkKCWdNw55pWMzy2ywgC84MQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-5.43.0.tgz",
+      "integrity": "sha512-FojrYadcsqo2UnlfewkOD5Gcnl+tqdRdNnFwiTHCWCSbLLh07a0rxPTjma91DtVWEUb+5bgzPl2lg9izhB53MQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@strapi/logger": "5.41.1",
-        "@strapi/types": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/logger": "5.43.0",
+        "@strapi/types": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "chalk": "4.1.2",
         "cli-table3": "0.6.5",
         "commander": "8.3.0",
         "fs-extra": "11.2.0",
         "inquirer": "9.3.8",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "ora": "5.4.1",
         "resolve-cwd": "3.0.0",
         "semver": "7.5.4",
@@ -6337,57 +6373,26 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/data-transfer/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@strapi/data-transfer/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/@strapi/data-transfer/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@strapi/database": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-5.41.1.tgz",
-      "integrity": "sha512-bkbA89PcmxCInMFJekc3s/Bk16iu2kKsakWF3pxnxYv56ReAZdyf1xTk0Tx+agsgbQGdzTPpiQzVFFX33RiGlg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-5.43.0.tgz",
+      "integrity": "sha512-xLpWkp2tnmDt95fCXM03PtGtcs0XQALdR+/z6N1joevRCSuOk9B9F3RPiU6qDFCt+XEsUMQ8yTZ3T/AzUBcJ5g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@paralleldrive/cuid2": "2.2.2",
-        "@strapi/utils": "5.41.1",
+        "@strapi/utils": "5.43.0",
         "ajv": "8.18.0",
         "date-fns": "2.30.0",
         "debug": "4.3.4",
         "fs-extra": "11.2.0",
         "knex": "3.0.1",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "semver": "7.5.4",
         "umzug": "3.8.1"
       },
@@ -6396,42 +6401,11 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/database/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@strapi/database/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
-    },
-    "node_modules/@strapi/database/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     },
     "node_modules/@strapi/design-system": {
       "version": "2.2.0",
@@ -6479,17 +6453,17 @@
       "license": "MIT"
     },
     "node_modules/@strapi/email": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/email/-/email-5.41.1.tgz",
-      "integrity": "sha512-dJThPP84wyQO2/Zm4pLUHrAo6dgWDvzvK+nyPIHsZY+xaXhH0Fl4I/BhTC8x9O6J/sD5L27/0h67jLVdY7JuFQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/email/-/email-5.43.0.tgz",
+      "integrity": "sha512-bdu//zvzwwQi9MeqBQXXmQpvbRXTvr1JxApl2vjW3ivb2qFU4izRqxNXa40ckc+/HTqOJ2z4GTqKVcSLH00ZuA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/provider-email-sendmail": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/provider-email-sendmail": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "koa2-ratelimit": "^1.1.3",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "react-intl": "6.6.2",
         "react-query": "3.39.3",
         "yup": "0.32.9",
@@ -6508,32 +6482,10 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/email/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@strapi/email/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/@strapi/email/node_modules/zod": {
@@ -6546,19 +6498,19 @@
       }
     },
     "node_modules/@strapi/generators": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-5.41.1.tgz",
-      "integrity": "sha512-K8tQPQMuLZ6lPJEXyq8ATaPqp0PyOzMWf9Fu4tkUszFY/wSF9BxNr4fETl2miM42flapbZXKjLZSwTZZP4q5xQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-5.43.0.tgz",
+      "integrity": "sha512-1u0L07nRc05tSSo/WesqVjok2dHezs7R/C+RLWF4bsqMKMCtBmImDLwp0HR1a+ai2aR9TVTjdp6z+l3Mbz8H6A==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/typescript-utils": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/typescript-utils": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "chalk": "4.1.2",
         "fs-extra": "11.2.0",
-        "handlebars": "4.7.7",
+        "handlebars": "4.7.9",
         "jscodeshift": "17.3.0",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "plop": "4.0.5",
         "pluralize": "8.0.0"
       },
@@ -6567,54 +6519,23 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/generators/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@strapi/generators/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/@strapi/generators/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@strapi/i18n": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/i18n/-/i18n-5.41.1.tgz",
-      "integrity": "sha512-NdaYCGg7pJmW0B8YxvGqoHFPvXoGc2IacsU16sG9b/irPAxYGHmEimJfOL1Zfl/Kl+H8snHrojpLfKqx435AbA==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/i18n/-/i18n-5.43.0.tgz",
+      "integrity": "sha512-zIhkQNC2sjso4clWiA2NIpDoFxd70otboLeOJ6BpgkRLEjMn+VVT1rmBUHo8I6lnccmMUHU6MZaaXwK5RcsW7g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@reduxjs/toolkit": "1.9.7",
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/utils": "5.41.1",
-        "lodash": "4.17.23",
+        "@strapi/utils": "5.43.0",
+        "lodash": "4.18.1",
         "qs": "6.15.0",
         "react-intl": "6.6.2",
         "react-redux": "8.1.3",
@@ -6634,33 +6555,74 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/i18n/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@strapi/i18n/node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/i18n/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/@strapi/i18n/node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@strapi/i18n/node_modules/zod": {
       "version": "3.25.67",
@@ -6683,12 +6645,12 @@
       }
     },
     "node_modules/@strapi/logger": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-5.41.1.tgz",
-      "integrity": "sha512-1DDjNV1ZRLK02Ns0ySIdnaNmogRuB49vANyMl2c0Zg/DnM20NI6nQNc3gK7ZWJZnDJ42qA9qsbmp3lShJmTX9A==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-5.43.0.tgz",
+      "integrity": "sha512-DzbHCSU+38WlY11fTNYN81iMjeV1/4WAgXnEo/+QXcPmcc0rSGDqYwvp/+bg6W6QvZVzLVZduZR6k8DJfwP8oA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "winston": "3.10.0"
       },
       "engines": {
@@ -6697,15 +6659,15 @@
       }
     },
     "node_modules/@strapi/logger/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/@strapi/openapi": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/openapi/-/openapi-5.41.1.tgz",
-      "integrity": "sha512-bnIAfXrVNDlP5j8J/kvfEfQnc/0vvsJTVSwMsTeF+XyjqmwhLqou9N9ENB8GoEN0iwZIqDtNAh5hVqAk+ky+rQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/openapi/-/openapi-5.43.0.tgz",
+      "integrity": "sha512-9pqfViqvEbycq13JcquEWR/RRc1GJbt3O903Cw9NI/YukaKLmgSR/J1qqIRoem2tTP8L6/8r/8UxZwu2p+0PNQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "debug": "4.3.4",
@@ -6727,14 +6689,14 @@
       }
     },
     "node_modules/@strapi/permissions": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-5.41.1.tgz",
-      "integrity": "sha512-wDvE3MBh0ww6HdX0uv4TH+ucDU5vdKNRsHwLdsu7hsD5AffAcNMqMiL74bm8X9dWGeWZ05DJnIQRXDPAmXYefg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-5.43.0.tgz",
+      "integrity": "sha512-B1tev0zQoyFiw1+7s6LN0RFKEAXkJMCz6QIpCGZo/MuUAMjpDvS5R7Ghh/0PuGmVjcDmM7q2DesdithSRwY78w==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@casl/ability": "6.7.5",
-        "@strapi/utils": "5.41.1",
-        "lodash": "4.17.23",
+        "@strapi/utils": "5.43.0",
+        "lodash": "4.18.1",
         "qs": "6.15.0",
         "sift": "16.0.1"
       },
@@ -6743,47 +6705,16 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/permissions/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@strapi/permissions/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/@strapi/permissions/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@strapi/plugin-graphql": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-graphql/-/plugin-graphql-5.40.0.tgz",
-      "integrity": "sha512-OHClF1FQgCuQI2YV6jhPbJ/jrjB8DZf6L2a77alWKEn0llJG0QzMD9TgAGMpcBaoZIxwdtiL6qV+MRzbuu5gBQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-graphql/-/plugin-graphql-5.43.0.tgz",
+      "integrity": "sha512-oImoxp7rw6LmA00Cpds7DgdaXeDn1xBsTmmaPW+/6KjPR9bSiWA9Gvqqu65WpF1Lt78MpupEl9mM2tw0TYTkbQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@apollo/server": "4.13.0",
@@ -6793,14 +6724,14 @@
         "@koa/cors": "5.0.0",
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/utils": "5.40.0",
+        "@strapi/utils": "5.43.0",
         "graphql": "^16.8.1",
         "graphql-depth-limit": "^1.1.0",
         "graphql-playground-middleware-koa": "^1.6.21",
         "graphql-scalars": "1.22.2",
         "koa-bodyparser": "4.4.1",
         "koa-compose": "^4.1.0",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "nexus": "1.3.0",
         "pluralize": "8.0.0"
       },
@@ -6817,29 +6748,29 @@
       }
     },
     "node_modules/@strapi/plugin-graphql/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/@strapi/plugin-users-permissions": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-5.40.0.tgz",
-      "integrity": "sha512-qK8vOmULiAuWotPtuX8PmSOXCK8FMVW0dwAO0vfNgksjkGtgFQAyd8OUEktaAXrbvtb2LfS3dOpBkJtEbgAfxQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-5.43.0.tgz",
+      "integrity": "sha512-sQaplY4LkBD3ZlqoxE/D2ArqfYagEPhU253KtLBwVyQ39TpjI7QNlMx4FK1b8aqgC1t+4F3uhkHDW7BuzqmoiQ==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/utils": "5.40.0",
+        "@strapi/utils": "5.43.0",
         "bcryptjs": "2.4.3",
         "formik": "2.4.5",
         "grant": "^5.4.8",
         "immer": "9.0.21",
         "jsonwebtoken": "9.0.0",
-        "jwk-to-pem": "2.0.5",
+        "jwk-to-pem": "2.0.7",
         "koa": "2.16.4",
         "koa2-ratelimit": "^1.1.3",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "prop-types": "^15.8.1",
         "purest": "4.0.2",
         "react-intl": "6.6.2",
@@ -6862,10 +6793,49 @@
       }
     },
     "node_modules/@strapi/plugin-users-permissions/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/@strapi/plugin-users-permissions/node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@strapi/plugin-users-permissions/node_modules/zod": {
       "version": "3.25.67",
@@ -6877,12 +6847,12 @@
       }
     },
     "node_modules/@strapi/provider-email-sendmail": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-5.41.1.tgz",
-      "integrity": "sha512-wEWO8soqsgDu+ZX1xZkxcLqJGLdMfA/sGTn6lumnQrVfQjG+zpLRaoRkX9137JQT1aNqPAhBIQla0+WCxMkH3A==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-5.43.0.tgz",
+      "integrity": "sha512-1KsJR+WWICDfjwWJTP+5QzxPsAO+SE0yzxJ7laOv0pCnSRsK376dmp6Xobn1Zqnh6z9Uag90yPVZanUnHXHMiA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@strapi/utils": "5.41.1",
+        "@strapi/utils": "5.43.0",
         "sendmail": "^1.6.1"
       },
       "engines": {
@@ -6890,50 +6860,13 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/provider-email-sendmail/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/@strapi/provider-email-sendmail/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
-    "node_modules/@strapi/provider-email-sendmail/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@strapi/provider-upload-local": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-5.41.1.tgz",
-      "integrity": "sha512-CHvyj9oaMb+TLAHzxTnpewdIlhMBtGTBO7If5EIBbynTRxFHnXgV3PrFYkB6fxwFQ/YEjV4SIhFafuifJQPUbg==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-5.43.0.tgz",
+      "integrity": "sha512-wtAimqekDlIBTShF0Yjc+L132jJuQJHV2W92zpqD2ckJfVrBq9XVTf1DHosRQRF0iohz4wiIsSy6/URW3jBiUw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@strapi/utils": "5.41.1",
+        "@strapi/utils": "5.43.0",
         "fs-extra": "11.2.0"
       },
       "engines": {
@@ -6941,53 +6874,16 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/provider-upload-local/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/@strapi/provider-upload-local/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
-    "node_modules/@strapi/provider-upload-local/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@strapi/review-workflows": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/review-workflows/-/review-workflows-5.41.1.tgz",
-      "integrity": "sha512-ZlIMotDC0+gnQvtPZJzBZM/VZwll+AzfjKl6l6dHn8kiXEL6pvltgawIObDsnOGZmzwecYMRROjuZtnFYtyIOA==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/review-workflows/-/review-workflows-5.43.0.tgz",
+      "integrity": "sha512-hsLwugZH//46gzY74EInkVzlcbhv4Q9rje9YhQV8GoBMhA5yiZXfdXiflDUjxe9KweHwb/TwPykVGE8tO2/qYg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@reduxjs/toolkit": "1.9.7",
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/utils": "5.41.1",
+        "@strapi/utils": "5.43.0",
         "fractional-indexing": "3.2.0",
         "react-dnd": "16.0.1",
         "react-dnd-html5-backend": "16.0.1",
@@ -7009,69 +6905,95 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/review-workflows/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@strapi/review-workflows/node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@strapi/review-workflows/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
-    "node_modules/@strapi/review-workflows/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+    "node_modules/@strapi/review-workflows/node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/strapi": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-5.41.1.tgz",
-      "integrity": "sha512-/ssnxyooLfC2rwQHFnDcn2sk+033L5YKGBmkRgbWhhDH1E42vPzPD9i3wRMz7h/GhMUIYwa3NOUZo5/7z1g9vw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-5.43.0.tgz",
+      "integrity": "sha512-vJLU9hOWcELgZmOOqHLRAfyc8AX4Jz58vvCoQApxCs6zFYhx50OPVD6BBeo1TS9Gp33yeRVclpqwHGxfeoWs5g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
-        "@strapi/admin": "5.41.1",
-        "@strapi/cloud-cli": "5.41.1",
-        "@strapi/content-manager": "5.41.1",
-        "@strapi/content-releases": "5.41.1",
-        "@strapi/content-type-builder": "5.41.1",
-        "@strapi/core": "5.41.1",
-        "@strapi/data-transfer": "5.41.1",
-        "@strapi/database": "5.41.1",
-        "@strapi/email": "5.41.1",
-        "@strapi/generators": "5.41.1",
-        "@strapi/i18n": "5.41.1",
-        "@strapi/logger": "5.41.1",
-        "@strapi/openapi": "5.41.1",
-        "@strapi/permissions": "5.41.1",
-        "@strapi/review-workflows": "5.41.1",
-        "@strapi/types": "5.41.1",
-        "@strapi/typescript-utils": "5.41.1",
-        "@strapi/upload": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/admin": "5.43.0",
+        "@strapi/cloud-cli": "5.43.0",
+        "@strapi/content-manager": "5.43.0",
+        "@strapi/content-releases": "5.43.0",
+        "@strapi/content-type-builder": "5.43.0",
+        "@strapi/core": "5.43.0",
+        "@strapi/data-transfer": "5.43.0",
+        "@strapi/database": "5.43.0",
+        "@strapi/email": "5.43.0",
+        "@strapi/generators": "5.43.0",
+        "@strapi/i18n": "5.43.0",
+        "@strapi/logger": "5.43.0",
+        "@strapi/openapi": "5.43.0",
+        "@strapi/permissions": "5.43.0",
+        "@strapi/review-workflows": "5.43.0",
+        "@strapi/types": "5.43.0",
+        "@strapi/typescript-utils": "5.43.0",
+        "@strapi/upload": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "@types/nodemon": "1.19.6",
         "@vitejs/plugin-react-swc": "3.6.0",
         "boxen": "5.1.2",
@@ -7095,7 +7017,7 @@
         "git-url-parse": "14.0.0",
         "html-webpack-plugin": "5.6.0",
         "inquirer": "9.3.8",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "mini-css-extract-plugin": "2.7.7",
         "nodemon": "3.0.2",
         "ora": "5.4.1",
@@ -7129,56 +7051,25 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/strapi/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@strapi/strapi/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/@strapi/strapi/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@strapi/types": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/types/-/types-5.41.1.tgz",
-      "integrity": "sha512-dA42l6XrcyyMfS+cpu1HG4J8GRyFfzTbc1izsAuFg7LV+YI2laC7RyycZFtQYN642XNsAhN1Uj3LlJfUqn4naw==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/types/-/types-5.43.0.tgz",
+      "integrity": "sha512-hDhnzOpsCk6dbgbOZG6faMmMdX8QFvvt4+qqfBUJzZivuCU/2cWRAV3TzCX/84Gz8FNeihxGZztB7Vco/ZkpTA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@casl/ability": "6.7.5",
         "@koa/cors": "5.0.0",
         "@koa/router": "12.0.2",
-        "@strapi/database": "5.41.1",
-        "@strapi/logger": "5.41.1",
-        "@strapi/permissions": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/database": "5.43.0",
+        "@strapi/logger": "5.43.0",
+        "@strapi/permissions": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "commander": "8.3.0",
         "json-logic-js": "2.0.5",
         "koa": "2.16.4",
@@ -7194,42 +7085,14 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/types/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
-      },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/@strapi/types/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
-    },
-    "node_modules/@strapi/types/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
     },
     "node_modules/@strapi/types/node_modules/minimatch": {
       "version": "9.0.9",
@@ -7313,15 +7176,15 @@
       }
     },
     "node_modules/@strapi/typescript-utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-5.41.1.tgz",
-      "integrity": "sha512-sfRpZzfAA1k4f7YlJtVVq2d9POgqOfw5nkBIxUmTm4+bMtPA8SOwVCwnPrv1Piwjfq7xNMcIbzKoRmBQUWzk8g==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-5.43.0.tgz",
+      "integrity": "sha512-hPUyxPzpF7ho+hrD5o9UzPpJXbWCf7FDInIwHhM8eUvwsP/rMOsA9Yal3KezBX01FTErLaB8WCzQiDcfna7kGw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "chalk": "4.1.2",
         "cli-table3": "0.6.5",
         "fs-extra": "11.2.0",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "prettier": "3.3.3",
         "typescript": "5.4.4"
       },
@@ -7331,9 +7194,9 @@
       }
     },
     "node_modules/@strapi/typescript-utils/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/@strapi/ui-primitives": {
@@ -7382,30 +7245,30 @@
       }
     },
     "node_modules/@strapi/upload": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/upload/-/upload-5.41.1.tgz",
-      "integrity": "sha512-yPGBnjFJbHQ9Ulq7+02leIvpObFx3tB6E1OBForHK0OwKb4qOUP2TMTthu4Xzh1lMHvKWMgApPf+6e+LaoQwtQ==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/upload/-/upload-5.43.0.tgz",
+      "integrity": "sha512-bg+7T13h/DEnKqq4lBlZ9xMKQinwuKOY9Ab4QffftgFUx/JzuD6SObenjhZ+8Q9v1OcopmcBj37+5zCgeT88sA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@mux/mux-player-react": "3.1.0",
         "@radix-ui/react-dialog": "1.0.5",
         "@radix-ui/react-toggle-group": "1.1.11",
         "@reduxjs/toolkit": "1.9.7",
-        "@strapi/database": "5.41.1",
+        "@strapi/database": "5.43.0",
         "@strapi/design-system": "2.2.0",
         "@strapi/icons": "2.2.0",
-        "@strapi/provider-upload-local": "5.41.1",
-        "@strapi/utils": "5.41.1",
+        "@strapi/provider-upload-local": "5.43.0",
+        "@strapi/utils": "5.43.0",
         "byte-size": "8.1.1",
         "cropperjs": "1.6.1",
         "date-fns": "2.30.0",
-        "file-type": "21.3.3",
+        "file-type": "21.3.4",
         "formik": "2.4.5",
         "fs-extra": "11.2.0",
         "immer": "9.0.21",
         "koa-range": "0.3.0",
         "koa-static": "5.0.0",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "mime-types": "2.1.35",
         "prop-types": "^15.8.1",
         "qs": "6.15.0",
@@ -7436,16 +7299,19 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-collection": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
-      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
         "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -7462,22 +7328,7 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-context": {
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-context": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
@@ -7492,7 +7343,7 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-direction": {
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
       "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
@@ -7507,25 +7358,7 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-primitive": {
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
@@ -7548,7 +7381,40 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-roving-focus": {
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
       "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
@@ -7579,7 +7445,33 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-slot": {
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
@@ -7597,7 +7489,70 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle": {
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-toggle": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
       "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
@@ -7622,51 +7577,7 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
-      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-toggle": "1.1.10",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-use-controllable-state": {
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
       "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
@@ -7685,7 +7596,25 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@radix-ui/react-use-layout-effect": {
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
@@ -7700,33 +7629,74 @@
         }
       }
     },
-    "node_modules/@strapi/upload/node_modules/@strapi/utils": {
-      "version": "5.41.1",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.41.1.tgz",
-      "integrity": "sha512-NmjF+3igvF7gtSnu9vchzvZcaDgiRfPbRJsRg8bLWvn7UrWFmFMzWGNDywcHTXLbxXQZDUbc5eUpDDU0Q2zUgg==",
-      "license": "SEE LICENSE IN LICENSE",
+    "node_modules/@strapi/upload/node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "date-fns": "2.30.0",
-        "execa": "5.1.1",
-        "http-errors": "2.0.0",
-        "lodash": "4.17.23",
-        "node-machine-id": "1.1.12",
-        "p-map": "4.0.0",
-        "preferred-pm": "3.1.3",
-        "yup": "0.32.9",
-        "zod": "3.25.67"
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
       },
-      "engines": {
-        "node": ">=20.0.0 <=24.x.x",
-        "npm": ">=6.0.0"
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/upload/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/@strapi/upload/node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@strapi/upload/node_modules/zod": {
       "version": "3.25.67",
@@ -7738,16 +7708,16 @@
       }
     },
     "node_modules/@strapi/utils": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.40.0.tgz",
-      "integrity": "sha512-SM3VDIMQln48mHHxa/U8DpmK64oQzYfEEgNjiAmLZoqTqAb4c/GXAjqT6cpREt/Da4IKmCw9wsDtLr7neklqBA==",
+      "version": "5.43.0",
+      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-5.43.0.tgz",
+      "integrity": "sha512-WMMzqoqb90fqzEX1xpnsSWb5XzyIfZtrdj3MDcHMIJT8QoZa/ntsAiPak9JpeQpPRkGdH62zvbQYMhupvP91IA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "date-fns": "2.30.0",
         "execa": "5.1.1",
         "http-errors": "2.0.0",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "node-machine-id": "1.1.12",
         "p-map": "4.0.0",
         "preferred-pm": "3.1.3",
@@ -7760,9 +7730,9 @@
       }
     },
     "node_modules/@strapi/utils/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/@strapi/utils/node_modules/zod": {
@@ -8043,12 +8013,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
-      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.23"
+        "@tanstack/virtual-core": "3.14.0"
       },
       "funding": {
         "type": "github",
@@ -8060,9 +8030,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.23",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
-      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8562,9 +8532,9 @@
       "license": "MIT"
     },
     "node_modules/@types/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -9406,14 +9376,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -10092,9 +10062,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/castable-video": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.12.tgz",
-      "integrity": "sha512-fSHLEq6cUb+5TMMxTrYV9Yc7RJvcyz0IvjQpGFmjX55CTNZ/OzPlp0GLQl3YWligG57H80q6FrbgOJ9+jFeIgA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.13.tgz",
+      "integrity": "sha512-yIdbRPi7k04FXsQaMb9RtsWw5GELiNF21ERoD5WUhU4e3rsVmOB12UX+LUUPWhTw3kPpjndnYyy4mHlFU3qSxw==",
       "license": "MIT",
       "dependencies": {
         "custom-media-element": "~1.4.6"
@@ -12333,9 +12303,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -12542,9 +12512,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
-      "integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
@@ -12730,9 +12700,9 @@
       }
     },
     "node_modules/flow-parser": {
-      "version": "0.307.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.307.1.tgz",
-      "integrity": "sha512-MIkG26VVtubK0OKgqY17oaMDgCIPgeEMt+XcdNho+aHldUH0uWkQ1uhf8TGxac99vOPTPpUh5OSK5LAmtXUvZQ==",
+      "version": "0.310.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.310.0.tgz",
+      "integrity": "sha512-LyOrE2R6Emgkp41ODL5L7giPJRYB70nbNYjzJUcMWl8Sh7vBhcWXvPmWIFhVoFuIOBxckO/+42CGnWUOE16UVw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -13490,18 +13460,6 @@
         "node": ">=6.6.0"
       }
     },
-    "node_modules/grant/node_modules/jwk-to-pem": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.7.tgz",
-      "integrity": "sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "asn1.js": "^5.3.0",
-        "elliptic": "^6.6.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/graphql": {
       "version": "16.13.2",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
@@ -13578,13 +13536,13 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -15149,13 +15107,13 @@
       }
     },
     "node_modules/jwk-to-pem": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.5.tgz",
-      "integrity": "sha512-L90jwellhO8jRKYwbssU9ifaMVqajzj3fpRjDKcsDzrslU9syRbFqfkXtT4B89HYAap+xsxNcxgBSB09ig+a7A==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.7.tgz",
+      "integrity": "sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "asn1.js": "^5.3.0",
-        "elliptic": "^6.5.4",
+        "elliptic": "^6.6.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -17242,12 +17200,12 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -17399,9 +17357,9 @@
       }
     },
     "node_modules/mux-embed": {
-      "version": "5.17.10",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.17.10.tgz",
-      "integrity": "sha512-i+eaoezVxIEliYGWPsjQztrWbA8A3Rzwqhwv1WGuRrl2npx85jFYJV5y+cjh7FASPOjT+7zJTYCJfxmcbgM7Hg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.18.0.tgz",
+      "integrity": "sha512-y/iRQIUIyRUL+5zUHynrMMMpRlWVXfEFvSwTx7h//qIguQ4BQdQtc3qhKEdGaSikTeVuDeVC5IwP4aDuHUpjIA==",
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -17546,36 +17504,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/node-plop/node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/node-plop/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/node-releases": {
@@ -18292,9 +18220,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -18950,10 +18878,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -19112,9 +19043,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0.tgz",
+      "integrity": "sha512-RPutkJftSAldDibyrjuku7q11d3oy6wKOyPe5K1HA/HwwrXcEqBdHsLypkC2FFYjP7bPUa6gbzSBhw4sY2JcDg==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19163,16 +19094,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-zaKdLBftQJnvb7FtDIpZtsAIb2MZU087RM8bRDZU8LVCCFYjPTsDZJNFUWPcVz3HFSN1n/caxi0ca4B/aaVQGQ==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.23.1"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^18.3.0"
       }
     },
     "node_modules/react-dom/node_modules/scheduler": {
@@ -19310,45 +19241,6 @@
           "optional": true
         },
         "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-redux": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
-      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4 || ^5.0.0-beta.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "redux": {
           "optional": true
         }
       }
@@ -21577,13 +21469,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -21936,9 +21828,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/cms/package.json
+++ b/cms/package.json
@@ -13,12 +13,12 @@
   "dependencies": {
     "@_sh/strapi-plugin-ckeditor": "7.1.1",
     "strapi-plugin-sso": "1.0.8",
-    "@strapi/plugin-graphql": "5.40.0",
-    "@strapi/plugin-users-permissions": "5.40.0",
-    "@strapi/strapi": "5.41.1",
+    "@strapi/plugin-graphql": "5.43.0",
+    "@strapi/plugin-users-permissions": "5.43.0",
+    "@strapi/strapi": "5.43.0",
     "pg": "8.8.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "18.3.0",
+    "react-dom": "18.3.0",
     "react-router-dom": "6.30.3",
     "styled-components": "6.3.12"
   },

--- a/frontend/src/app/services/content-resolver.ts
+++ b/frontend/src/app/services/content-resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
-import { Observable, catchError, map } from 'rxjs';
+import { Observable, catchError, filter, map, of, take } from 'rxjs';
 import { Apollo, gql } from 'apollo-angular';
 import { Page } from '@app/models/content/page';
 
@@ -10,6 +10,8 @@ import { Page } from '@app/models/content/page';
 export class ContentResolver implements Resolve<Page> {
 
     constructor(private readonly apollo: Apollo){}
+
+    private readonly defaultPage = new Page();
 
     private getPage = function(route){
 
@@ -38,12 +40,16 @@ export class ContentResolver implements Resolve<Page> {
     resolve(route: ActivatedRouteSnapshot): Observable<Page> {
     // Return an Observable that represents the GraphQL request to execute before the route is activated.
         return this.apollo.watchQuery<any>({
-            query: this.getPage(route.routeConfig.path)
+            query: this.getPage(route.routeConfig.path),
         })
-        .valueChanges.pipe(map(result => result.data?.pageByRoute as Page),
-        catchError(error => {
-            console.error(error);
-            return [];
-        }))
+        .valueChanges.pipe(
+          filter((result) => !result.loading),
+          map((result) => (result.data?.pageByRoute as Page) || this.defaultPage),
+          take(1),
+          catchError((error) => {
+            console.error('ContentResolver GraphQL request failed:', error);
+            return of(this.defaultPage);
+          })
+        )
     }
 }

--- a/frontend/src/app/services/home-resolver.ts
+++ b/frontend/src/app/services/home-resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Resolve } from '@angular/router';
-import { Observable, catchError, map, of } from 'rxjs';
+import { Observable, catchError, filter, map, of, take } from 'rxjs';
 import { Apollo, gql } from 'apollo-angular';
 import { Home } from '@app/models/content/home';
 import { FastFact} from '@app/models/content/fast-fact'
@@ -97,13 +97,17 @@ export class HomeResolver implements Resolve<HomeResponse> {
     resolve(): Observable<HomeResponse> {
     // Return an Observable that represents the GraphQL request to execute before the route is activated.
         return this.apollo.watchQuery<any>({
-            query: this.getHome()
+            query: this.getHome(),
         })
-        .valueChanges.pipe(map(result => this.buildResponse(result.data)),
-        catchError(error => {
-          //Failed to fetch content for HomePage from CMS. Fallback to hard coded defaults.
-          console.error(error);
-          return of(this.defaultResponse);
-        }))
+        .valueChanges.pipe(
+          filter((result) => !result.loading),
+          map((result) => this.buildResponse(result.data)),
+          take(1),
+          catchError((error) => {
+            // Failed to fetch content for HomePage from CMS. Fallback to hard coded defaults.
+            console.error('HomeResolver GraphQL request failed:', error);
+            return of(this.defaultResponse);
+          })
+        )
     }
 }


### PR DESCRIPTION

# Description

This PR fixes an issue where some of the content blocks loaded through graphql does not show in test after the strapi upgrade:

Before:
<img width="1274" height="610" alt="image" src="https://github.com/user-attachments/assets/1418d34d-d1de-4119-a1aa-12502123a149" />

AFter:

<img width="1104" height="1055" alt="image" src="https://github.com/user-attachments/assets/75d7a032-8b1a-4f34-9056-5f20d494ac90" />

Cause: The `apollo` `watchQuery` function now returns an intermediate `{isLoading: true}` response before the full response, so just filtering that one out


- Also upgrades strapi to the latest version that was just released

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)




---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-bcmi-183-frontend.apps.silver.devops.gov.bc.ca)
- [CMS](https://nr-bcmi-183-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-bcmi-183-frontend.apps.silver.devops.gov.bc.ca)
- [CMS](https://nr-bcmi-183-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/merge.yml)