### PR TITLE
[MDS-6909] Add missing published filter to page resolver, fix processes & procedures not showing up

### DIFF
--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -18,6 +18,7 @@ export default {
           pageByRoute: {
             resolve: async (parent, args, context) => {
               const data = await strapi.documents("api::page.page").findMany({
+                status: "published",
                 filters: {route: args.route},
               });
               return data[0] || null;

--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -60,7 +60,9 @@
               <div class="feature-block">
                 <h3>{{block.Title}}</h3>
                 <p>{{block.Description}}</p>
-                <a class="btn inverted" [routerLink]="block.page.route">Learn More</a>
+                @if (block.page?.route) {
+                  <a class="btn inverted" [routerLink]="block.page.route">Learn More</a>
+                }
               </div>
             </div>
           }
@@ -88,7 +90,9 @@
               <div class="feature-block">
                 <h3>{{block.Title}}</h3>
                 <p>{{block.Description}}</p>
-                <a class="btn inverted" [routerLink]="block.page.route">Learn More</a>
+                @if (block.page?.route) {
+                  <a class="btn inverted" [routerLink]="block.page.route">Learn More</a>
+                }
               </div>
             </div>
           }


### PR DESCRIPTION

# Description

Fixes an issue where you can see unpublished drafts after editing page content in Strapi.
Source: a missing `published` filter.

Also, fixed an issue sometime preventing the "Processes & Procedures" section from rendering.

Before: 

<img width="1004" height="898" alt="image" src="https://github.com/user-attachments/assets/22c2c612-1c05-4c50-9258-f4bedd468c7e" />


After:
<img width="1057" height="917" alt="image" src="https://github.com/user-attachments/assets/b0252c3d-e319-4038-843c-33de5ecb2bf2" />


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-bcmi-185-frontend.apps.silver.devops.gov.bc.ca)
- [CMS](https://nr-bcmi-185-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-bcmi/actions/workflows/merge.yml)